### PR TITLE
fix: fix multi arch builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [ "published" ]
   push:
-    branches: [ "main", "fix-multi-arch-build" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [ "published" ]
   push:
-    branches: [ "main", "fix-multi-arch-build" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -88,7 +88,7 @@ jobs:
   release:
     name: Upload release binaries
     if: github.event_name == 'release'
-    needs: build
+    needs: ["build-linux-amd64", "build-darwin-amd64"]
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Upload workflow artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: plugin-binaries-linux
+        name: plugin-binaries-darwin-arm64
         path: age-plugin-fido2-hmac*
 
   build-darwin-arm64:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,6 +50,7 @@ jobs:
           tar -cvzf "age-plugin-fido2-hmac-$VERSION-$GOOS-$GOARCH.tar.gz" -C "$DIR" age-plugin-fido2-hmac
         fi
       env:
+        CGO_ENABLED: 0
         GOOS: ${{ matrix.GOOS }}
         GOARCH: ${{ matrix.GOARCH }}
         GOARM: ${{ matrix.GOARM }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -126,42 +126,43 @@ jobs:
         name: plugin-binaries-darwin-amd64
         path: age-plugin-fido2-hmac*
 
-  build-windows-amd64:
-    runs-on: windows-latest
-    steps:
-    - uses: actions/checkout@v4
+  # TODO: fix and uncomment if needed
+  # build-windows-amd64:
+  #   runs-on: windows-latest
+  #   steps:
+  #   - uses: actions/checkout@v4
 
-    - name: Set up Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ env.GO_VERSION }}
+  #   - name: Set up Go
+  #     uses: actions/setup-go@v5
+  #     with:
+  #       go-version: ${{ env.GO_VERSION }}
 
-    - name: Install libfido2
-      run: |
-        Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
-        Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
-        scoop bucket add keys.pub https://github.com/keys-pub/scoop-bucket
-        scoop install libfido2
+  #   - name: Install libfido2
+  #     run: |
+  #       Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+  #       Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+  #       scoop bucket add keys.pub https://github.com/keys-pub/scoop-bucket
+  #       scoop install libfido2
 
-    - name: Test
-      run: go test -v ./...
+  #   - name: Test
+  #     run: go test -v ./...
 
-    - name: Package
-      run: |
-        VERSION="$(git describe --tags --always)"
-        go build -ldflags "-X main.Version=$VERSION" -v ./cmd/...
-        DIR="$(mktemp -d)"
-        mkdir "$DIR/age-plugin-fido2-hmac"
-        cp LICENSE "$DIR/age-plugin-fido2-hmac"
-        mv age-plugin-fido2-hmac "$DIR/age-plugin-fido2-hmac"
-        OLDDIR="$(pwd)"
-        cd "$DIR"
-        zip age-plugin-fido2-hmac.zip -r age-plugin-fido2-hmac
-        cd "$OLDDIR"
-        mv "$DIR/age-plugin-fido2-hmac.zip" "age-plugin-fido2-hmac-$VERSION-windows-amd64.zip"
-      env:
-        CGO_ENABLED: ${{ env.CGO_ENABLED }}
-        GOARCH: amd64
+  #   - name: Package
+  #     run: |
+  #       VERSION="$(git describe --tags --always)"
+  #       go build -ldflags "-X main.Version=$VERSION" -v ./cmd/...
+  #       DIR="$(mktemp -d)"
+  #       mkdir "$DIR/age-plugin-fido2-hmac"
+  #       cp LICENSE "$DIR/age-plugin-fido2-hmac"
+  #       mv age-plugin-fido2-hmac "$DIR/age-plugin-fido2-hmac"
+  #       OLDDIR="$(pwd)"
+  #       cd "$DIR"
+  #       zip age-plugin-fido2-hmac.zip -r age-plugin-fido2-hmac
+  #       cd "$OLDDIR"
+  #       mv "$DIR/age-plugin-fido2-hmac.zip" "age-plugin-fido2-hmac-$VERSION-windows-amd64.zip"
+  #     env:
+  #       CGO_ENABLED: ${{ env.CGO_ENABLED }}
+  #       GOARCH: amd64
 
     - name: Upload workflow artifacts
       uses: actions/upload-artifact@v4
@@ -172,7 +173,7 @@ jobs:
   release:
     name: Upload release binaries
     if: github.event_name == 'release'
-    needs: ["build-linux-amd64", "build-darwin-amd64", "build-darwin-arm64", "build-windows-amd64"]
+    needs: ["build-linux-amd64", "build-darwin-amd64", "build-darwin-arm64"]
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -154,7 +154,10 @@ jobs:
         mkdir "$DIR/age-plugin-fido2-hmac"
         cp LICENSE "$DIR/age-plugin-fido2-hmac"
         mv age-plugin-fido2-hmac "$DIR/age-plugin-fido2-hmac"
-        ( cd "$DIR"; zip age-plugin-fido2-hmac.zip -r age-plugin-fido2-hmac )
+        OLDDIR="$(pwd)"
+        cd "$DIR"
+        zip age-plugin-fido2-hmac.zip -r age-plugin-fido2-hmac
+        cd "$OLDDIR"
         mv "$DIR/age-plugin-fido2-hmac.zip" "age-plugin-fido2-hmac-$VERSION-windows-amd64.zip"
       env:
         CGO_ENABLED: ${{ env.CGO_ENABLED }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -126,10 +126,50 @@ jobs:
         name: plugin-binaries-darwin-amd64
         path: age-plugin-fido2-hmac*
 
+  build-windows-amd64:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    - uses: MinoruSekine/setup-scoop@v2
+    - name: Install libfido2
+      run: |
+        Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+        Invoke-RestMethod -Uri https://get.scoop.sh | Invoke-Expression
+        scoop bucket add keys.pub https://github.com/keys-pub/scoop-bucket
+        scoop install libfido2
+
+    - name: Test
+      run: go test -v ./...
+
+    - name: Package
+      run: |
+        VERSION="$(git describe --tags --always)"
+        go build -ldflags "-X main.Version=$VERSION" -v ./cmd/...
+        DIR="$(mktemp -d)"
+        mkdir "$DIR/age-plugin-fido2-hmac"
+        cp LICENSE "$DIR/age-plugin-fido2-hmac"
+        mv age-plugin-fido2-hmac "$DIR/age-plugin-fido2-hmac"
+        tar -cvzf "age-plugin-fido2-hmac-$VERSION-windows-amd64.tar.gz" -C "$DIR" age-plugin-fido2-hmac
+      env:
+        CGO_ENABLED: ${{ env.CGO_ENABLED }}
+        GOARCH: amd64
+
+    - name: Upload workflow artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: plugin-binaries-windows-amd64
+        path: age-plugin-fido2-hmac*
+
   release:
     name: Upload release binaries
     if: github.event_name == 'release'
-    needs: ["build-linux-amd64", "build-darwin-amd64", "build-darwin-arm64"]
+    needs: ["build-linux-amd64", "build-darwin-amd64", "build-darwin-arm64", "build-windows-arm64"]
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [ "published" ]
   push:
-    branches: [ "main" ]
+    branches: [ "main", "fix-multi-arch-build" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Upload workflow artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: plugin-binaries-darwin-arm64
+        name: plugin-binaries-linux
         path: age-plugin-fido2-hmac*
 
   build-darwin-arm64:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -154,7 +154,8 @@ jobs:
         mkdir "$DIR/age-plugin-fido2-hmac"
         cp LICENSE "$DIR/age-plugin-fido2-hmac"
         mv age-plugin-fido2-hmac "$DIR/age-plugin-fido2-hmac"
-        tar -cvzf "age-plugin-fido2-hmac-$VERSION-windows-amd64.tar.gz" -C "$DIR" age-plugin-fido2-hmac
+        ( cd "$DIR"; zip age-plugin-fido2-hmac.zip -r age-plugin-fido2-hmac )
+        mv "$DIR/age-plugin-fido2-hmac.zip" "age-plugin-fido2-hmac-$VERSION-windows-amd64.zip"
       env:
         CGO_ENABLED: ${{ env.CGO_ENABLED }}
         GOARCH: amd64

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -48,6 +48,39 @@ jobs:
         name: plugin-binaries-linux
         path: age-plugin-fido2-hmac*
 
+  build-darwin-arm64:
+    runs-on: macos-13
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+
+    - name: Install libfido2
+      run: brew install libfido2
+
+    - name: Test
+      run: go test -v ./...
+
+    - name: Package
+      run: |
+        VERSION="$(git describe --tags --always)"
+        go build -ldflags "-X main.Version=$VERSION" -v ./cmd/...
+        DIR="$(mktemp -d)"
+        mkdir "$DIR/age-plugin-fido2-hmac"
+        cp LICENSE "$DIR/age-plugin-fido2-hmac"
+        mv age-plugin-fido2-hmac "$DIR/age-plugin-fido2-hmac"
+        tar -cvzf "age-plugin-fido2-hmac-$VERSION-darwin-arm64.tar.gz" -C "$DIR" age-plugin-fido2-hmac
+      env:
+        CGO_ENABLED: ${{ env.CGO_ENABLED }}
+        GOARCH: arm64
+
   build-darwin-amd64:
     runs-on: macos-13
     steps:
@@ -90,7 +123,7 @@ jobs:
   release:
     name: Upload release binaries
     if: github.event_name == 'release'
-    needs: ["build-linux-amd64", "build-darwin-amd64"]
+    needs: ["build-linux-amd64", "build-darwin-amd64", "build-darwin-arm64"]
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -79,6 +79,7 @@ jobs:
         tar -cvzf "age-plugin-fido2-hmac-$VERSION-darwin-amd64.tar.gz" -C "$DIR" age-plugin-fido2-hmac
       env:
         CGO_ENABLED: ${{ env.CGO_ENABLED }}
+        GOARCH: amd64
 
     - name: Upload workflow artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Upload workflow artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: plugin-binaries
+        name: plugin-binaries-linux
         path: age-plugin-fido2-hmac*
 
   build-darwin-amd64:
@@ -82,7 +82,7 @@ jobs:
     - name: Upload workflow artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: plugin-binaries
+        name: plugin-binaries-darwin
         path: age-plugin-fido2-hmac*
 
   release:
@@ -94,9 +94,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download workflow artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: plugin-binaries
+        uses: actions/download-artifact@v4
+
       - name: Upload release artifacts
         run: gh release upload "$GITHUB_REF_NAME" age-plugin-fido2-hmac*
         env:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -62,7 +62,7 @@ jobs:
       uses: Homebrew/actions/setup-homebrew@master
 
     - name: Install libfido2
-      run: brew install libfido2 openssl@3
+      run: brew install libfido2
 
     - name: Test
       run: go test -v ./...

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
         path: age-plugin-fido2-hmac*
 
   build-darwin-amd64:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Upload workflow artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: plugin-binaries-darwin-amd64
+        name: plugin-binaries-darwin-arm64
         path: age-plugin-fido2-hmac*
 
   build-darwin-amd64:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -62,7 +62,7 @@ jobs:
       uses: Homebrew/actions/setup-homebrew@master
 
     - name: Install libfido2
-      run: brew install libfido2
+      run: brew install libfido2 openssl@3
 
     - name: Test
       run: go test -v ./...

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,29 +8,23 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  GO_VERSION: '>=1.22.1'
+  CGO_ENABLED: 1
+
 jobs:
-  build:
+  build-linux-amd64:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - {GOOS: linux, GOARCH: amd64}
-          - {GOOS: linux, GOARCH: arm, GOARM: 6}
-          - {GOOS: linux, GOARCH: arm64}
-          - {GOOS: darwin, GOARCH: amd64}
-          - {GOOS: darwin, GOARCH: arm64}
-          - {GOOS: windows, GOARCH: amd64}
-          - {GOOS: freebsd, GOARCH: amd64}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.22'
+        go-version: ${{ env.GO_VERSION }}
 
     - name: Install libfido2
-      run: sudo apt install libfido2-1 libfido2-dev libfido2-doc fido2-tools
+      run: sudo apt-get install -y libfido2-dev
 
     - name: Test
       run: go test -v ./...
@@ -43,20 +37,50 @@ jobs:
         mkdir "$DIR/age-plugin-fido2-hmac"
         cp LICENSE "$DIR/age-plugin-fido2-hmac"
         mv age-plugin-fido2-hmac "$DIR/age-plugin-fido2-hmac"
-        if [ "$GOOS" == "windows" ]; then
-          ( cd "$DIR"; zip age-plugin-fido2-hmac.zip -r age-plugin-fido2-hmac )
-          mv "$DIR/age-plugin-fido2-hmac.zip" "age-plugin-fido2-hmac-$VERSION-$GOOS-$GOARCH.zip"
-        else
-          tar -cvzf "age-plugin-fido2-hmac-$VERSION-$GOOS-$GOARCH.tar.gz" -C "$DIR" age-plugin-fido2-hmac
-        fi
+        tar -cvzf "age-plugin-fido2-hmac-$VERSION-linux-amd64.tar.gz" -C "$DIR" age-plugin-fido2-hmac
       env:
-        CGO_ENABLED: 0
-        GOOS: ${{ matrix.GOOS }}
-        GOARCH: ${{ matrix.GOARCH }}
-        GOARM: ${{ matrix.GOARM }}
+        CGO_ENABLED: ${{ env.CGO_ENABLED }}
 
     - name: Upload workflow artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
+      with:
+        name: plugin-binaries
+        path: age-plugin-fido2-hmac*
+
+  build-darwin-amd64:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: ${{ env.GO_VERSION }}
+
+    - name: Set up Homebrew
+      id: set-up-homebrew
+      uses: Homebrew/actions/setup-homebrew@master
+
+    - name: Install libfido2
+      run: brew install libfido2
+
+    - name: Test
+      run: go test -v ./...
+
+    - name: Package
+      run: |
+        VERSION="$(git describe --tags --always)"
+        go build -ldflags "-X main.Version=$VERSION" -v ./cmd/...
+        DIR="$(mktemp -d)"
+        mkdir "$DIR/age-plugin-fido2-hmac"
+        cp LICENSE "$DIR/age-plugin-fido2-hmac"
+        mv age-plugin-fido2-hmac "$DIR/age-plugin-fido2-hmac"
+        tar -cvzf "age-plugin-fido2-hmac-$VERSION-darwin-amd64.tar.gz" -C "$DIR" age-plugin-fido2-hmac
+      env:
+        CGO_ENABLED: ${{ env.CGO_ENABLED }}
+
+    - name: Upload workflow artifacts
+      uses: actions/upload-artifact@v4
       with:
         name: plugin-binaries
         path: age-plugin-fido2-hmac*

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,17 +32,13 @@ jobs:
     - name: Install libfido2
       run: sudo apt install libfido2-1 libfido2-dev libfido2-doc fido2-tools
 
-    - name: Build
-      run: |
-        VERSION="$(git describe --tags --always)"
-        go build -ldflags "-X main.Version=$VERSION" -v ./cmd/...
-
     - name: Test
       run: go test -v ./...
 
     - name: Package
       run: |
         VERSION="$(git describe --tags --always)"
+        go build -ldflags "-X main.Version=$VERSION" -v ./cmd/...
         DIR="$(mktemp -d)"
         mkdir "$DIR/age-plugin-fido2-hmac"
         cp LICENSE "$DIR/age-plugin-fido2-hmac"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,6 +40,7 @@ jobs:
         tar -cvzf "age-plugin-fido2-hmac-$VERSION-linux-amd64.tar.gz" -C "$DIR" age-plugin-fido2-hmac
       env:
         CGO_ENABLED: ${{ env.CGO_ENABLED }}
+        GOARCH: amd64
 
     - name: Upload workflow artifacts
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -136,7 +136,6 @@ jobs:
       with:
         go-version: ${{ env.GO_VERSION }}
 
-    - uses: MinoruSekine/setup-scoop@v2
     - name: Install libfido2
       run: |
         Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
@@ -169,7 +168,7 @@ jobs:
   release:
     name: Upload release binaries
     if: github.event_name == 'release'
-    needs: ["build-linux-amd64", "build-darwin-amd64", "build-darwin-arm64", "build-windows-arm64"]
+    needs: ["build-linux-amd64", "build-darwin-amd64", "build-darwin-arm64", "build-windows-amd64"]
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
         path: age-plugin-fido2-hmac*
 
   build-darwin-arm64:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -81,6 +81,12 @@ jobs:
         CGO_ENABLED: ${{ env.CGO_ENABLED }}
         GOARCH: arm64
 
+    - name: Upload workflow artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: plugin-binaries-darwin-amd64
+        path: age-plugin-fido2-hmac*
+
   build-darwin-amd64:
     runs-on: macos-13
     steps:
@@ -117,7 +123,7 @@ jobs:
     - name: Upload workflow artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: plugin-binaries-darwin
+        name: plugin-binaries-darwin-amd64
         path: age-plugin-fido2-hmac*
 
   release:

--- a/README.md
+++ b/README.md
@@ -18,9 +18,39 @@
 - [age](https://github.com/FiloSottile/age) (>= 1.1.0) or [rage](https://github.com/str4d/rage)
 - [libfido2](https://developers.yubico.com/libfido2/)
 
+**Ubuntu (>= 20.04)**
+
+```bash
+sudo apt install libfido2-1 libfido2-dev libfido2-doc fido2-tools
+```
+
+**Fedora (>= 34)**
+
+```bash
+sudo dnf install libfido2 libfido2-devel fido2-tools
+```
+
+**Mac OS**
+
+```bash
+brew install libfido2
+```
+
 ## Installation
 
 Download a the latest binary from the [release page](https://github.com/olastor/age-plugin-fido2-hmac/releases). Copy the binary to your `$PATH` (preferably in `$(which age)`) and make sure it's executable.
+
+You can also use the following script for installation:
+
+- Installs binary to `~/.local/bin/age-plugin-fido2-hmac` (change to your preferred directory)
+- Make sure to adjust `OS` and `ARCH` if needed (`OS=darwin ARCH=arm64` for Apple Silicon, `OS=darwin ARCH=amd64` for older Macs)
+
+```bash
+cd "$(mktemp -d)"
+VERSION=v0.2.1 OS=linux ARCH=amd64; curl -L "https://github.com/olastor/age-plugin-fido2-hmac/releases/download/$VERSION/age-plugin-fido2-hmac-$VERSION-$OS-$ARCH.tar.gz" -o age-plugin-fido2-hmac.tar.gz
+tar -xzf age-plugin-fido2-hmac.tar.gz
+mv age-plugin-fido2-hmac/age-plugin-fido2-hmac ~/.local/bin
+```
 
 ## Build from source
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can also use the following script for installation:
 
 ```bash
 cd "$(mktemp -d)"
-VERSION=v0.2.1 OS=linux ARCH=amd64; curl -L "https://github.com/olastor/age-plugin-fido2-hmac/releases/download/$VERSION/age-plugin-fido2-hmac-$VERSION-$OS-$ARCH.tar.gz" -o age-plugin-fido2-hmac.tar.gz
+VERSION=v0.2.2 OS=linux ARCH=amd64; curl -L "https://github.com/olastor/age-plugin-fido2-hmac/releases/download/$VERSION/age-plugin-fido2-hmac-$VERSION-$OS-$ARCH.tar.gz" -o age-plugin-fido2-hmac.tar.gz
 tar -xzf age-plugin-fido2-hmac.tar.gz
 mv age-plugin-fido2-hmac/age-plugin-fido2-hmac ~/.local/bin
 ```

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.22.1
 require filippo.io/age v1.1.2-0.20230920124100-101cc8676386
 
 require (
-	github.com/keys-pub/go-libfido2 v1.5.3
+	github.com/keys-pub/go-libfido2 v1.5.4-0.20230628153049-536daffdd394
 	github.com/olastor/age-plugin-controller v0.1.0
 	golang.org/x/crypto v0.22.0
 	golang.org/x/sys v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ filippo.io/age v1.1.2-0.20230920124100-101cc8676386/go.mod h1:y3Zb/i2jHg/kL8xc3o
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/keys-pub/go-libfido2 v1.5.3 h1:vtgHxlSB43u6lj0TSuA3VvT6z3E7VI+L1a2hvMFdECk=
-github.com/keys-pub/go-libfido2 v1.5.3/go.mod h1:P0V19qHwJNY0htZwZDe9Ilvs/nokGhdFX7faKFyZ6+U=
+github.com/keys-pub/go-libfido2 v1.5.4-0.20230628153049-536daffdd394 h1:zf+3yRJH5NIVOhLceS4P6AVQWEgQPhMCpxgMSB46HdI=
+github.com/keys-pub/go-libfido2 v1.5.4-0.20230628153049-536daffdd394/go.mod h1:92J9LtSBl0UyUWljElJpTbMMNhC6VeY8dshsu40qjjo=
 github.com/olastor/age-plugin-controller v0.1.0 h1:5P3ftQ+sJ7FPExvss9IPAaik7x0eRoCkV4Hx09tUwi8=
 github.com/olastor/age-plugin-controller v0.1.0/go.mod h1:6Smtnn5sTHNcLLGPFY/Ea4rKZg5VkfCyC/FTMw6Fyfs=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
@@ -20,12 +20,12 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 golang.org/x/crypto v0.22.0 h1:g1v0xeRhjcugydODzvb3mEM9SQ0HGp9s/nh3COQ/C30=
 golang.org/x/crypto v0.22.0/go.mod h1:vr6Su+7cTlO45qkww3VDJlzDn0ctJvRgYbC2NvXHt+M=
-golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.19.0 h1:q5f1RH2jigJ1MoAWp2KTp3gm5zAGFUTarQZ5U386+4o=
 golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.19.0 h1:+ThwsDv+tYfnJFhF4L8jITxu1tdTWRTZpdsWgEgjL6Q=
 golang.org/x/term v0.19.0/go.mod h1:2CuTdWZ7KHSQwUzKva0cbMg6q2DMI3Mmxp+gKJbskEk=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
- fix builds for darwin 
- update libfido2 dependency to fix issue with mac os (https://github.com/keys-pub/go-libfido2/issues/38)
- build each binary on its OS
- explicitly set `CGO_ENABLED=1` when building
- remove windows builds for now
- update actions versions
- improve install instructions