### PR TITLE
Support post-quantum MLKEM768-X25519 hybrid keys

### DIFF
--- a/cmd/age-plugin-fido2-hmac/main.go
+++ b/cmd/age-plugin-fido2-hmac/main.go
@@ -16,13 +16,14 @@ import (
 var Version string
 
 const USAGE = `Usage:
-  age-plugin-fido2-hmac [-s] [-a ALG] -g
+  age-plugin-fido2-hmac [-s] [-p] [-a ALG] -g
   age-plugin-fido2-hmac -m
 
 Options:
     -g, --generate        Generate new credentials interactively.
     -s, --symmetric       Use symmetric encryption and use a new salt for every encryption.
                           The token must be present for every operation.
+    -p, --post-quantum    Use post-quantum MLKEM768-X25519 hybrid encryption instead of X25519.
     -m, --magic-identity  Print the magic identity to use when no identity is required.
     -a, --algorithm       Choose a specific algorithm when creating the fido2 credential.
                           Can be one of 'es256', 'eddsa', or 'rs256'. Default: es256
@@ -50,6 +51,7 @@ func main() {
 		helpFlag            bool
 		versionFlag         bool
 		symmetricFlag       bool
+		postQuantumFlag     bool
 		deprecatedMagicFlag bool
 	)
 
@@ -69,6 +71,9 @@ func main() {
 
 	flag.BoolVar(&symmetricFlag, "s", false, "")
 	flag.BoolVar(&symmetricFlag, "symmetric", false, "")
+
+	flag.BoolVar(&postQuantumFlag, "p", false, "")
+	flag.BoolVar(&postQuantumFlag, "post-quantum", false, "")
 
 	flag.BoolVar(&versionFlag, "v", false, "")
 	flag.BoolVar(&versionFlag, "version", false, "")
@@ -105,7 +110,7 @@ func main() {
 			}
 		}
 
-		x25519Recipient, fido2HmacRecipient, fido2HmacIdentity, err := plugin.NewCredentialsCli(algorithm, symmetricFlag)
+		x25519Recipient, hybridRecipient, fido2HmacRecipient, fido2HmacIdentity, err := plugin.NewCredentialsCli(algorithm, symmetricFlag, postQuantumFlag)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Failed: %s", err)
 			os.Exit(1)
@@ -120,6 +125,10 @@ func main() {
 
 		if x25519Recipient != nil {
 			recipientStr = x25519Recipient.String()
+		}
+
+		if hybridRecipient != nil {
+			recipientStr = hybridRecipient.String()
 		}
 
 		if fido2HmacIdentity != nil {
@@ -179,7 +188,7 @@ func main() {
 				// would lead to re-asking for the PIN when the plugin controller calls Wrap().
 				// One idea might be to save the PIN in the recipient structure or create a custom recipient
 				// type and ask for the PIN here, but I'd like to avoid that.
-				_, fido2HmacRecipient, _, err := plugin.NewCredentials(libfido2.ES256, false, &ui, false)
+				_, _, fido2HmacRecipient, _, err := plugin.NewCredentials(libfido2.ES256, false, false, &ui, false)
 				if err != nil {
 					return nil, err
 				}

--- a/cmd/age-plugin-fido2-hmac/main.go
+++ b/cmd/age-plugin-fido2-hmac/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"os"
@@ -17,6 +18,7 @@ var Version string
 
 const USAGE = `Usage:
   age-plugin-fido2-hmac [-s] [-p] [-a ALG] -g
+  age-plugin-fido2-hmac -y [-i IDENTITY]
   age-plugin-fido2-hmac -m
 
 Options:
@@ -24,6 +26,9 @@ Options:
     -s, --symmetric       Use symmetric encryption and use a new salt for every encryption.
                           The token must be present for every operation.
     -p, --post-quantum    Use post-quantum MLKEM768-X25519 hybrid encryption instead of X25519.
+    -y                    Read an identity file and output the corresponding recipient.
+                          Reads from stdin if no -i flag is given.
+    -i                    Identity file to read (used with -y).
     -m, --magic-identity  Print the magic identity to use when no identity is required.
     -a, --algorithm       Choose a specific algorithm when creating the fido2 credential.
                           Can be one of 'es256', 'eddsa', or 'rs256'. Default: es256
@@ -47,7 +52,9 @@ func main() {
 	var (
 		pluginFlag          string
 		algorithmFlag       string
+		identityFileFlag    string
 		generateFlag        bool
+		convertFlag         bool
 		helpFlag            bool
 		versionFlag         bool
 		symmetricFlag       bool
@@ -74,6 +81,9 @@ func main() {
 
 	flag.BoolVar(&postQuantumFlag, "p", false, "")
 	flag.BoolVar(&postQuantumFlag, "post-quantum", false, "")
+
+	flag.BoolVar(&convertFlag, "y", false, "")
+	flag.StringVar(&identityFileFlag, "i", "", "")
 
 	flag.BoolVar(&versionFlag, "v", false, "")
 	flag.BoolVar(&versionFlag, "version", false, "")
@@ -140,6 +150,109 @@ func main() {
 		} else {
 			_, _ = fmt.Fprint(os.Stdout, "# for decryption, use `age -d -j fido2-hmac` without any identity file.\n")
 			_, _ = fmt.Fprintf(os.Stdout, "# public key: %s\n%s\n", recipientStr, identityStr)
+		}
+
+		os.Exit(0)
+	}
+
+	if convertFlag {
+		var input *os.File
+		if identityFileFlag != "" {
+			f, err := os.Open(identityFileFlag)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to open identity file: %s\n", err)
+				os.Exit(1)
+			}
+			defer f.Close()
+			input = f
+		} else {
+			input = os.Stdin
+		}
+
+		// scan for identity lines
+		var identityStr string
+		scanner := bufio.NewScanner(input)
+		for scanner.Scan() {
+			line := strings.TrimSpace(scanner.Text())
+			if strings.HasPrefix(line, "#") || line == "" {
+				continue
+			}
+			if strings.HasPrefix(strings.ToUpper(line), "AGE-PLUGIN-FIDO2-HMAC-") {
+				identityStr = line
+				break
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to read identity: %s\n", err)
+			os.Exit(1)
+		}
+
+		if identityStr == "" {
+			fmt.Fprintf(os.Stderr, "No fido2-hmac identity found in input\n")
+			os.Exit(1)
+		}
+
+		identity, err := plugin.ParseFido2HmacIdentity(identityStr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to parse identity: %s\n", err)
+			os.Exit(1)
+		}
+
+		if identity.CredId == nil {
+			fmt.Fprintf(os.Stderr, "Cannot convert a dataless identity to a recipient\n")
+			os.Exit(1)
+		}
+
+		fmt.Fprintf(os.Stderr, "Please insert your token...\n")
+		device, err := plugin.FindDevice(50*time.Second, func(msg string) error {
+			fmt.Fprintf(os.Stderr, "%s\n", msg)
+			return nil
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to find device: %s\n", err)
+			os.Exit(1)
+		}
+		identity.Device = device
+
+		printf := func(format string, v ...any) {
+			fmt.Fprintf(os.Stderr, format, v...)
+		}
+		ui := page.NewTerminalUI(printf, printf)
+		identity.UI = ui
+
+		pin, err := identity.ObtainSecretFromToken("")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to obtain secret: %s\n", err)
+			os.Exit(1)
+		}
+		_ = pin
+
+		recipient, err := identity.Recipient()
+		identity.ClearSecret()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Failed to derive recipient: %s\n", err)
+			os.Exit(1)
+		}
+
+		switch identity.Version {
+		case 1:
+			fmt.Println(recipient.String())
+		case 2:
+			x25519Recipient, err := recipient.X25519Recipient()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to encode recipient: %s\n", err)
+				os.Exit(1)
+			}
+			fmt.Println(x25519Recipient.String())
+		case 3:
+			hybridRecipient, err := recipient.HybridRecipient()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Failed to encode recipient: %s\n", err)
+				os.Exit(1)
+			}
+			fmt.Println(hybridRecipient.String())
+		default:
+			fmt.Println(recipient.String())
 		}
 
 		os.Exit(0)

--- a/pkg/plugin/cli.go
+++ b/pkg/plugin/cli.go
@@ -18,9 +18,10 @@ import (
 func NewCredentials(
 	algorithm libfido2.CredentialType,
 	symmetric bool,
+	postQuantum bool,
 	ui *page.ClientUI,
 	askForIdentity bool,
-) (*age.X25519Recipient, *Fido2HmacRecipient, *Fido2HmacIdentity, error) {
+) (*age.X25519Recipient, *age.HybridRecipient, *Fido2HmacRecipient, *Fido2HmacIdentity, error) {
 	var device *libfido2.Device
 
 	displayMessage := func(message string) error {
@@ -29,41 +30,41 @@ func NewCredentials(
 
 	err := displayMessage("Please insert your token now...\n")
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	device, err = FindDevice(50*time.Second, displayMessage)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	hasPinSet, err := HasPinSet(device)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	pin := ""
 	if hasPinSet {
 		pin, err = ui.RequestValue(PLUGIN_NAME, "Please enter your PIN:", true)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 	}
 
 	err = displayMessage("Please touch your token...\n")
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 	credId, err := generateNewCredential(device, pin, algorithm)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	requirePin := false
 	if hasPinSet {
 		requirePin, err = ui.Confirm(PLUGIN_NAME, "Do you want to require a PIN for decryption?", "yes", "no")
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 	}
 
@@ -74,6 +75,7 @@ func NewCredentials(
 	var identity *Fido2HmacIdentity
 	var recipient *Fido2HmacRecipient
 	var x25519Recipient *age.X25519Recipient
+	var hybridRecipient *age.HybridRecipient
 
 	if symmetric {
 		identity = &Fido2HmacIdentity{
@@ -86,16 +88,21 @@ func NewCredentials(
 		}
 		recipient, err = identity.Recipient()
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 	} else {
 		salt := make([]byte, 32)
 		if _, err := rand.Read(salt); err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
+		}
+
+		identityVersion := uint16(2)
+		if postQuantum {
+			identityVersion = 3
 		}
 
 		identity = &Fido2HmacIdentity{
-			Version:    2,
+			Version:    identityVersion,
 			RequirePin: requirePin,
 			Salt:       salt,
 			CredId:     credId,
@@ -105,18 +112,25 @@ func NewCredentials(
 
 		_, err = identity.obtainSecretFromToken(pin)
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 
 		recipient, err = identity.Recipient()
 		identity.ClearSecret()
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 
-		x25519Recipient, err = recipient.X25519Recipient()
-		if err != nil {
-			return nil, nil, nil, err
+		if postQuantum {
+			hybridRecipient, err = recipient.HybridRecipient()
+			if err != nil {
+				return nil, nil, nil, nil, err
+			}
+		} else {
+			x25519Recipient, err = recipient.X25519Recipient()
+			if err != nil {
+				return nil, nil, nil, nil, err
+			}
 		}
 	}
 
@@ -130,18 +144,20 @@ func NewCredentials(
 		)
 
 		if err != nil {
-			return nil, nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 	}
 
 	if wantsSeparateIdentity {
 		if recipient.Version == 1 {
-			return nil, recipient, identity, nil
+			return nil, nil, recipient, identity, nil
+		} else if recipient.Version == 3 {
+			return nil, hybridRecipient, nil, identity, nil
 		} else {
-			return x25519Recipient, nil, identity, nil
+			return x25519Recipient, nil, nil, identity, nil
 		}
 	} else {
-		return nil, recipient, nil, nil
+		return nil, nil, recipient, nil, nil
 	}
 }
 
@@ -150,7 +166,8 @@ const defaultPrintfPrefix = "%s plugin: "
 func NewCredentialsCli(
 	algorithm libfido2.CredentialType,
 	symmetric bool,
-) (*age.X25519Recipient, *Fido2HmacRecipient, *Fido2HmacIdentity, error) {
+	postQuantum bool,
+) (*age.X25519Recipient, *age.HybridRecipient, *Fido2HmacRecipient, *Fido2HmacIdentity, error) {
 	printf := func(format string, v ...any) {
 		if strings.HasPrefix(format, defaultPrintfPrefix) {
 			// try to use a nicer prefix if possible
@@ -169,6 +186,7 @@ func NewCredentialsCli(
 	return NewCredentials(
 		algorithm,
 		symmetric,
+		postQuantum,
 		ui,
 		true,
 	)

--- a/pkg/plugin/identity.go
+++ b/pkg/plugin/identity.go
@@ -21,6 +21,11 @@ func (i *Fido2HmacIdentity) X25519Identity() (*age.X25519Identity, error) {
 	return age.ParseX25519Identity(strings.ToUpper(identityStr))
 }
 
+func (i *Fido2HmacIdentity) HybridIdentity() (*age.HybridIdentity, error) {
+	identityStr, _ := bech32.Encode("AGE-SECRET-KEY-PQ-", i.secretKey)
+	return age.ParseHybridIdentity(strings.ToUpper(identityStr))
+}
+
 func (i *Fido2HmacIdentity) Recipient() (*Fido2HmacRecipient, error) {
 	switch i.Version {
 	case 1:
@@ -45,6 +50,27 @@ func (i *Fido2HmacIdentity) Recipient() (*Fido2HmacRecipient, error) {
 
 		return &Fido2HmacRecipient{
 			Version:        2,
+			TheirPublicKey: theirPublicKey,
+			RequirePin:     i.RequirePin,
+			Salt:           i.Salt,
+			CredId:         i.CredId,
+			Device:         i.Device,
+			Plugin:         i.Plugin,
+			UI:             i.UI,
+		}, nil
+	case 3:
+		hybridIdentity, err := i.HybridIdentity()
+		if err != nil {
+			return nil, err
+		}
+
+		_, theirPublicKey, err := bech32.Decode(hybridIdentity.Recipient().String())
+		if err != nil {
+			return nil, err
+		}
+
+		return &Fido2HmacRecipient{
+			Version:        3,
 			TheirPublicKey: theirPublicKey,
 			RequirePin:     i.RequirePin,
 			Salt:           i.Salt,
@@ -165,6 +191,28 @@ func (i *Fido2HmacIdentity) Wrap(fileKey []byte) ([]*age.Stanza, error) {
 
 		// encrypting with an identity means we can use an X25519 stanza
 		return x25519Recipient.Wrap(fileKey)
+	case 3:
+		_, err := i.obtainSecretFromToken("")
+		if err != nil {
+			return nil, err
+		}
+
+		if i.secretKey == nil || len(i.secretKey) != 32 {
+			return nil, fmt.Errorf("incomplete identity, missing or invalid secret key")
+		}
+
+		recipient, err := i.Recipient()
+		if err != nil {
+			return nil, err
+		}
+
+		hybridRecipient, err := recipient.HybridRecipient()
+		if err != nil {
+			return nil, err
+		}
+
+		// encrypting with an identity means we can use an mlkem768x25519 stanza
+		return hybridRecipient.Wrap(fileKey)
 	default:
 		return nil, fmt.Errorf("unsupported recipient version %x", i.Version)
 	}
@@ -177,6 +225,7 @@ func (i *Fido2HmacIdentity) Unwrap(stanzas []*age.Stanza) ([]byte, error) {
 
 	var pluginStanzas []*Fido2HmacStanza
 	var x25519Stanzas []*age.Stanza
+	var hybridStanzas []*age.Stanza
 
 	for _, stanza := range stanzas {
 		if stanza.Type == PLUGIN_NAME {
@@ -188,10 +237,12 @@ func (i *Fido2HmacIdentity) Unwrap(stanzas []*age.Stanza) ([]byte, error) {
 			pluginStanzas = append(pluginStanzas, stanzaData)
 		} else if stanza.Type == "X25519" && i.Version == 2 {
 			x25519Stanzas = append(x25519Stanzas, stanza)
+		} else if stanza.Type == "mlkem768x25519" && i.Version == 3 {
+			hybridStanzas = append(hybridStanzas, stanza)
 		}
 	}
 
-	if len(pluginStanzas)+len(x25519Stanzas) == 0 {
+	if len(pluginStanzas)+len(x25519Stanzas)+len(hybridStanzas) == 0 {
 		// there were stanzas provided, but non of them are compatible
 		// with the plugin or the identity version
 		return nil, age.ErrIncorrectIdentity
@@ -239,6 +290,32 @@ func (i *Fido2HmacIdentity) Unwrap(stanzas []*age.Stanza) ([]byte, error) {
 		}
 	}
 
+	// if the version is three and there is a cred id we expect to unwrap mlkem768x25519 stanzas
+	if i.Version == 3 && i.CredId != nil && len(hybridStanzas) > 0 {
+		if i.secretKey == nil {
+			pin, err = i.obtainSecretFromToken(pin)
+			if err != nil {
+				if errors.Is(err, libfido2.ErrNoCredentials) {
+					return nil, age.ErrIncorrectIdentity
+				}
+
+				return nil, err
+			}
+		}
+
+		hybridIdentity, err := i.HybridIdentity()
+		if err != nil {
+			return nil, err
+		}
+
+		fileKey, err := hybridIdentity.Unwrap(hybridStanzas)
+		i.ClearSecret()
+
+		if err == nil {
+			return fileKey, nil
+		}
+	}
+
 	for _, fidoStanza := range pluginStanzas {
 		if fidoStanza.CredId == nil && (i.CredId == nil || fidoStanza.Version != i.Version) {
 			// incompatible: cred id needs to exists in either stanza or identity
@@ -260,7 +337,7 @@ func (i *Fido2HmacIdentity) Unwrap(stanzas []*age.Stanza) ([]byte, error) {
 			id.RequirePin = fidoStanza.RequirePin
 		}
 
-		if i.Version != 2 || i.secretKey == nil || !slices.Equal(i.CredId, id.CredId) {
+		if (i.Version != 2 && i.Version != 3) || i.secretKey == nil || !slices.Equal(i.CredId, id.CredId) {
 			if (i.RequirePin || fidoStanza.RequirePin) && pin == "" {
 				pin, err = i.RequestSecret("Please enter you PIN:")
 				if err != nil {
@@ -305,14 +382,31 @@ func (i *Fido2HmacIdentity) Unwrap(stanzas []*age.Stanza) ([]byte, error) {
 				return nil, err
 			}
 
-			plaintext, err := x25519Identity.Unwrap([]*age.Stanza{&age.Stanza{
+			plaintext, err := x25519Identity.Unwrap([]*age.Stanza{{
 				Type: "X25519",
-				Args: []string{string(fidoStanza.X25519Share)},
+				Args: []string{fidoStanza.Share},
 				Body: fidoStanza.Body,
 			}})
 
 			if err != nil {
 				// TODO: differentiate error handling?
+				return nil, err
+			}
+
+			return plaintext, nil
+		case 3:
+			hybridIdentity, err := id.HybridIdentity()
+			if err != nil {
+				return nil, err
+			}
+
+			plaintext, err := hybridIdentity.Unwrap([]*age.Stanza{{
+				Type: "mlkem768x25519",
+				Args: []string{fidoStanza.Share},
+				Body: fidoStanza.Body,
+			}})
+
+			if err != nil {
 				return nil, err
 			}
 
@@ -379,7 +473,7 @@ func (i *Fido2HmacIdentity) String() string {
 		s, _ := bech32.Encode(IDENTITY_HRP, data)
 
 		return strings.ToUpper(s)
-	case 2:
+	case 2, 3:
 		data := slices.Concat(
 			version,
 			[]byte{requirePinByte},

--- a/pkg/plugin/identity.go
+++ b/pkg/plugin/identity.go
@@ -84,6 +84,12 @@ func (i *Fido2HmacIdentity) Recipient() (*Fido2HmacRecipient, error) {
 	}
 }
 
+// ObtainSecretFromToken obtains the HMAC secret from the FIDO2 token.
+// The pin can be passed if it's known already to avoid re-asking, but it's optional.
+func (i *Fido2HmacIdentity) ObtainSecretFromToken(pin string) (string, error) {
+	return i.obtainSecretFromToken(pin)
+}
+
 // the pin can be passed if it's known already to avoid re-asking, but it's optional
 func (i *Fido2HmacIdentity) obtainSecretFromToken(pin string) (string, error) {
 	if i.Device == nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -19,7 +19,8 @@ const (
 	RECIPIENT_HRP                = "age1" + PLUGIN_NAME
 	IDENTITY_HRP                 = "age-plugin-" + PLUGIN_NAME + "-"
 	RELYING_PARTY                = "age-encryption.org"
-	STANZA_FORMAT_VERSION uint16 = 2
+	STANZA_FORMAT_VERSION    uint16 = 2
+	STANZA_FORMAT_VERSION_PQ uint16 = 3
 )
 
 type Fido2HmacRecipient struct {
@@ -54,13 +55,13 @@ type Fido2HmacIdentity struct {
 
 // data structure for stanza with parsed args
 type Fido2HmacStanza struct {
-	Version     uint16
-	RequirePin  bool
-	Salt        []byte
-	CredId      []byte
-	X25519Share string
-	Nonce       []byte
-	Body        []byte
+	Version    uint16
+	RequirePin bool
+	Salt       []byte
+	CredId     []byte
+	Share      string // X25519 ephemeral share (V2) or MLKEM768X25519 enc (V3)
+	Nonce      []byte
+	Body       []byte
 }
 
 // Checks if an identity is a "data-less" identity. This method is backwards-compatible with older plugin versions that used a custom "magic" identity.
@@ -99,6 +100,16 @@ func ParseFido2HmacRecipient(recipient string) (*Fido2HmacRecipient, error) {
 			Salt:           data[35:67],
 			CredId:         data[67:],
 		}, nil
+	case 3:
+		// MLKEM768X25519 public key is 1216 bytes (1184 ML-KEM-768 + 32 X25519)
+		const pqPubKeySize = 1216
+		return &Fido2HmacRecipient{
+			Version:        3,
+			TheirPublicKey: data[2 : 2+pqPubKeySize],
+			RequirePin:     data[2+pqPubKeySize] == byte(1),
+			Salt:           data[2+pqPubKeySize+1 : 2+pqPubKeySize+1+32],
+			CredId:         data[2+pqPubKeySize+1+32:],
+		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported recipient version %x", format_version)
 	}
@@ -134,6 +145,14 @@ func ParseFido2HmacIdentity(identity string) (*Fido2HmacIdentity, error) {
 	case 2:
 		return &Fido2HmacIdentity{
 			Version:    2,
+			secretKey:  nil,
+			RequirePin: data[2] == byte(1),
+			Salt:       data[3:35],
+			CredId:     data[35:],
+		}, nil
+	case 3:
+		return &Fido2HmacIdentity{
+			Version:    3,
 			secretKey:  nil,
 			RequirePin: data[2] == byte(1),
 			Salt:       data[3:35],
@@ -182,8 +201,8 @@ func ParseFido2HmacStanza(stanza *age.Stanza) (*Fido2HmacStanza, error) {
 				return nil, fmt.Errorf("cred id in stanza is malformed")
 			}
 		}
-	case 2:
-		stanzaData.X25519Share = stanza.Args[1]
+	case 2, 3:
+		stanzaData.Share = stanza.Args[1]
 
 		requirePin, err := b64.DecodeString(stanza.Args[2])
 		if err != nil {

--- a/pkg/plugin/recipient.go
+++ b/pkg/plugin/recipient.go
@@ -14,6 +14,11 @@ func (r *Fido2HmacRecipient) X25519Recipient() (*age.X25519Recipient, error) {
 	return age.ParseX25519Recipient(recipientStr)
 }
 
+func (r *Fido2HmacRecipient) HybridRecipient() (*age.HybridRecipient, error) {
+	recipientStr, _ := bech32.Encode("age1pq", r.TheirPublicKey)
+	return age.ParseHybridRecipient(recipientStr)
+}
+
 func (r *Fido2HmacRecipient) String() string {
 	requirePinByte := byte(0)
 	if r.RequirePin {
@@ -33,7 +38,7 @@ func (r *Fido2HmacRecipient) String() string {
 
 		s, _ := bech32.Encode(RECIPIENT_HRP, data)
 		return s
-	case 2:
+	case 2, 3:
 		data := slices.Concat(
 			version,
 			r.TheirPublicKey,
@@ -108,6 +113,39 @@ func (r *Fido2HmacRecipient) Wrap(fileKey []byte) ([]*age.Stanza, error) {
 			Type: PLUGIN_NAME,
 			Args: stanzaArgs,
 			Body: x25519Stanzas[0].Body,
+		}
+
+		return []*age.Stanza{stanza}, nil
+	case 3:
+		hybridRecipient, err := r.HybridRecipient()
+		if err != nil {
+			return nil, err
+		}
+
+		hybridStanzas, err := hybridRecipient.Wrap(fileKey)
+		if err != nil {
+			return nil, err
+		}
+
+		requirePinByte := byte(0)
+		if r.RequirePin {
+			requirePinByte = byte(1)
+		}
+
+		version := make([]byte, 2)
+		binary.BigEndian.PutUint16(version, uint16(STANZA_FORMAT_VERSION_PQ))
+
+		stanzaArgs := make([]string, 5)
+		stanzaArgs[0] = b64.EncodeToString(version)
+		stanzaArgs[1] = hybridStanzas[0].Args[0]
+		stanzaArgs[2] = b64.EncodeToString([]byte{requirePinByte})
+		stanzaArgs[3] = b64.EncodeToString(r.Salt)
+		stanzaArgs[4] = b64.EncodeToString(r.CredId)
+
+		stanza := &age.Stanza{
+			Type: PLUGIN_NAME,
+			Args: stanzaArgs,
+			Body: hybridStanzas[0].Body,
 		}
 
 		return []*age.Stanza{stanza}, nil


### PR DESCRIPTION
This PR adds support for post-quantum keys.
The fido2 key uses es256/eddsa/rs256 for authentication, but most fido2-hmac implementations use symmetric crypto for the hmac secret, so we can use it to derive a PQ key.