### PR TITLE
Add command-scoped FIDO2 HMAC sessions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 build:
-	go build -ldflags "-X main.Version=$$(git describe --tags --always)" ./cmd/...
+	go build -ldflags "-X main.Version=$$(git describe --tags --always)" -o age-plugin-fido2-hmac ./cmd/age-plugin-fido2-hmac
+	go build -ldflags "-X main.Version=$$(git describe --tags --always)" -o age-plugin-fido2-hmac-session ./cmd/age-plugin-fido2-hmac-session
 
 test: build
 	go test -v ./...
@@ -17,4 +18,4 @@ lint-fix:
 	golangci-lint run --fix
 
 clean:
-	rm -f age-plugin-fido2-hmac
+	rm -f age-plugin-fido2-hmac age-plugin-fido2-hmac-session

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ git clone https://github.com/olastor/age-plugin-fido2-hmac.git
 cd age-plugin-fido2-hmac
 make build
 mv ./age-plugin-fido2-hmac ~/.local/bin/age-plugin-fido2-hmac
+mv ./age-plugin-fido2-hmac-session ~/.local/bin/age-plugin-fido2-hmac-session
 ```
 
 (requires Go 1.22)
@@ -119,6 +120,26 @@ age -d -i identity.txt -o test-decrypted.txt test.txt.enc
 ```
 
 (where `identity.txt` is a file you created putting the `AGE-PLUGIN-FIDO2-HMAC-1QQP...` separated identity you created before.)
+
+### Batch sessions
+
+The `age-plugin-fido2-hmac-session` companion command can wrap a command that
+decrypts several files:
+
+```bash
+age-plugin-fido2-hmac-session -- agenix rekey
+```
+
+For version-2 identities, the first decryption loads the derived identity into
+locked process memory and later plugin processes in the same session reuse it.
+The derived identity and PIN are never written to disk, and the session clears
+the key when the wrapped command exits. One physical touch is still required
+for each distinct identity used by the command. Version-1 and data-less
+identities retain their existing per-file user-presence behavior.
+
+This mode is intentionally command-scoped rather than a persistent agent. Do
+not use it to wrap untrusted commands: any child process in the session can ask
+the broker to decrypt files for the selected identity.
 
 ### Choosing a different algorithm
 

--- a/cmd/age-plugin-fido2-hmac-session/main.go
+++ b/cmd/age-plugin-fido2-hmac-session/main.go
@@ -1,0 +1,125 @@
+package main
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/olastor/age-plugin-fido2-hmac/pkg/plugin"
+)
+
+func main() {
+	args := os.Args[1:]
+	if len(args) > 0 && args[0] == "--" {
+		args = args[1:]
+	}
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "usage: age-plugin-fido2-hmac-session -- COMMAND [ARGS...]")
+		os.Exit(2)
+	}
+
+	baseDir := os.Getenv("XDG_RUNTIME_DIR")
+	if baseDir == "" {
+		baseDir = os.TempDir()
+	}
+	sessionDir, err := os.MkdirTemp(baseDir, "age-plugin-fido2-hmac-session-")
+	if err != nil {
+		fatal(err)
+	}
+	defer os.RemoveAll(sessionDir)
+	if err := os.Chmod(sessionDir, 0o700); err != nil {
+		fatal(err)
+	}
+
+	capability := make([]byte, 32)
+	if _, err := rand.Read(capability); err != nil {
+		fatal(fmt.Errorf("generate session capability: %w", err))
+	}
+
+	cache := plugin.NewSessionCache()
+	defer cache.Close()
+
+	server, err := plugin.NewSessionServer(filepath.Join(sessionDir, "session.sock"), capability, cache)
+	if err != nil {
+		fatal(err)
+	}
+	defer server.Close()
+
+	serverErr := make(chan error, 1)
+	go func() { serverErr <- server.Serve() }()
+
+	command := exec.Command(args[0], args[1:]...)
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	command.Env = sessionEnvironment(os.Environ(), server, capability)
+
+	if err := command.Start(); err != nil {
+		fatal(fmt.Errorf("start command: %w", err))
+	}
+
+	signalCh := make(chan os.Signal, 8)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
+	defer signal.Stop(signalCh)
+	go func() {
+		for sig := range signalCh {
+			if command.Process != nil {
+				_ = command.Process.Signal(sig)
+			}
+		}
+	}()
+
+	waitErr := command.Wait()
+	_ = server.Close()
+	select {
+	case err := <-serverErr:
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "session broker: %s\n", err)
+		}
+	default:
+	}
+
+	if waitErr == nil {
+		return
+	}
+	if exitErr, ok := waitErr.(*exec.ExitError); ok {
+		if code := exitErr.ProcessState.ExitCode(); code >= 0 {
+			os.Exit(code)
+		}
+	}
+	fatal(waitErr)
+}
+
+func sessionEnvironment(environment []string, server *plugin.SessionServer, capability []byte) []string {
+	// The wrapper only exports session credentials to its child command. Remove
+	// inherited values first so nested invocations cannot accidentally attach to
+	// an unrelated parent session.
+	filtered := make([]string, 0, len(environment)+2)
+	for _, entry := range environment {
+		if len(entry) > len(plugin.SessionSocketEnv) && entry[:len(plugin.SessionSocketEnv)] == plugin.SessionSocketEnv && entry[len(plugin.SessionSocketEnv)] == '=' {
+			continue
+		}
+		if len(entry) > len(plugin.SessionCapabilityEnv) && entry[:len(plugin.SessionCapabilityEnv)] == plugin.SessionCapabilityEnv && entry[len(plugin.SessionCapabilityEnv)] == '=' {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	filtered = append(filtered,
+		plugin.SessionSocketEnv+"="+serverSocket(server),
+		plugin.SessionCapabilityEnv+"="+plugin.SessionCapabilityString(capability),
+	)
+	return filtered
+}
+
+func serverSocket(server *plugin.SessionServer) string {
+	return server.SocketPath()
+}
+
+func fatal(err error) {
+	fmt.Fprintln(os.Stderr, err)
+	os.Exit(1)
+}

--- a/cmd/age-plugin-fido2-hmac/main.go
+++ b/cmd/age-plugin-fido2-hmac/main.go
@@ -88,6 +88,10 @@ const USAGE = `Usage:
   age-plugin-fido2-hmac -y [FILE]
   age-plugin-fido2-hmac -m
 
+The companion age-plugin-fido2-hmac-session command can wrap a batch command
+and reuse a version-2 FIDO2 identity for its lifetime. It keeps the derived
+secret in locked memory and clears it when the wrapped command exits.
+
 Options:
     -g, --generate        Generate new credentials interactively.
     -s, --symmetric       Use symmetric encryption and use a new salt for every encryption.
@@ -163,6 +167,19 @@ func main() {
 
 	if helpFlag {
 		flag.Usage()
+		os.Exit(0)
+	}
+
+	if pluginFlag == "identity-v1" && os.Getenv(plugin.SessionSocketEnv) != "" {
+		capability, err := plugin.ParseSessionCapability(os.Getenv(plugin.SessionCapabilityEnv))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "session broker: %s\n", err)
+			os.Exit(1)
+		}
+		if err := plugin.ProxySession(os.Getenv(plugin.SessionSocketEnv), capability); err != nil {
+			fmt.Fprintf(os.Stderr, "session broker: %s\n", err)
+			os.Exit(1)
+		}
 		os.Exit(0)
 	}
 

--- a/pkg/plugin/fido2_device.go
+++ b/pkg/plugin/fido2_device.go
@@ -54,14 +54,15 @@ func (d *LibFido2Device) Info() (*libfido2.DeviceInfo, error) {
 // MockFido2Device is a mock implementation of Fido2Device for testing.
 // It allows configuring expected responses and simulating various device behaviors.
 type MockFido2Device struct {
-	PinSet           bool
-	HasPinSetErr     error
-	GeneratedCredId  []byte
-	GenerateCredErr  error
-	HmacSecret       []byte
-	GetHmacSecretErr error
-	InfoValue        *libfido2.DeviceInfo
-	InfoErr          error
+	PinSet             bool
+	HasPinSetErr       error
+	GeneratedCredId    []byte
+	GenerateCredErr    error
+	HmacSecret         []byte
+	GetHmacSecretErr   error
+	GetHmacSecretCalls int
+	InfoValue          *libfido2.DeviceInfo
+	InfoErr            error
 }
 
 // HasPinSet returns the configured PIN status for testing.
@@ -76,6 +77,7 @@ func (m *MockFido2Device) GenerateCredential(pin string, algorithm libfido2.Cred
 
 // GetHmacSecret returns a pre-configured HMAC secret for testing.
 func (m *MockFido2Device) GetHmacSecret(credId []byte, salt []byte, pin string) ([]byte, error) {
+	m.GetHmacSecretCalls++
 	return m.HmacSecret, m.GetHmacSecretErr
 }
 

--- a/pkg/plugin/identity.go
+++ b/pkg/plugin/identity.go
@@ -89,13 +89,41 @@ func (i *Fido2HmacIdentity) LoadSecret(pin string) error {
 		return nil
 	}
 
+	// Version-2 identities derive the same native key for every age file. A
+	// command-scoped session may therefore reuse it without asking the token
+	// again. Version 1 deliberately remains uncached because its salt is part of
+	// each encrypted stanza.
+	if i.sessionCache != nil && i.Version == 2 && i.CredId != nil && i.sessionIdentity != "" {
+		secret, err := i.sessionCache.Load(i.sessionIdentity, func() ([]byte, error) {
+			return i.loadSecretFromToken(pin)
+		})
+		if err != nil {
+			return err
+		}
+		i.secretKey = secret
+		return nil
+	}
+
+	secret, err := i.loadSecretFromToken(pin)
+	if err != nil {
+		return err
+	}
+	i.secretKey = secret
+	return nil
+}
+
+func (i *Fido2HmacIdentity) loadSecretFromToken(pin string) ([]byte, error) {
+	if i.Device == nil {
+		return nil, fmt.Errorf("device not specified, cannot obtain secret")
+	}
+
 	if i.RequirePin && pin == "" {
-		return fmt.Errorf("pin required for this identity")
+		return nil, fmt.Errorf("pin required for this identity")
 	}
 
 	err := i.DisplayMessage("Please touch your token...")
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	unlockPin := ""
@@ -103,20 +131,23 @@ func (i *Fido2HmacIdentity) LoadSecret(pin string) error {
 		unlockPin = pin
 	}
 
-	i.secretKey, err = i.Device.GetHmacSecret(i.CredId, i.Salt, unlockPin)
+	secret, err := i.Device.GetHmacSecret(i.CredId, i.Salt, unlockPin)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	err = mlock.Mlock(i.secretKey)
+	err = mlock.Mlock(secret)
 	if err != nil {
 		err = i.DisplayMessage(fmt.Sprintf("Warning: Failed to call mlock: %s", err))
 		if err != nil {
-			return err
+			for j := range secret {
+				secret[j] = 0
+			}
+			return nil, err
 		}
 	}
 
-	return nil
+	return secret, nil
 }
 
 // internal method that returns the pin to avoid re-asking it
@@ -422,6 +453,13 @@ func (i *Fido2HmacIdentity) Unwrap(stanzas []*age.Stanza) ([]byte, error) {
 }
 
 func (i *Fido2HmacIdentity) ClearSecret() {
+	if i.sessionCache != nil && i.sessionIdentity != "" && i.Version == 2 && i.CredId != nil {
+		// The session owns and clears this byte slice. Individual plugin
+		// protocol connections must not zero a value still used by another
+		// connection in the same command.
+		return
+	}
+
 	if i.secretKey != nil {
 		for j := 0; j < cap(i.secretKey); j++ {
 			i.secretKey[j] = 0

--- a/pkg/plugin/identity_test.go
+++ b/pkg/plugin/identity_test.go
@@ -91,6 +91,66 @@ func TestLoadSecret_AlreadyLoaded(t *testing.T) {
 	assert.Equal(t, secret, id.secretKey, "secret should remain unchanged when already loaded")
 }
 
+func TestSessionCacheReusesVersion2Secret(t *testing.T) {
+	secret := make([]byte, 32)
+	_, err := rand.Read(secret)
+	require.NoError(t, err)
+
+	mockDevice := &MockFido2Device{HmacSecret: secret}
+	cache := NewSessionCache()
+	defer cache.Close()
+
+	identity := &Fido2HmacIdentity{
+		Version:         2,
+		Salt:            make([]byte, 32),
+		CredId:          make([]byte, 50),
+		Device:          mockDevice,
+		UI:              newMockUI(nil, func(string) error { return nil }, nil),
+		sessionCache:    cache,
+		sessionIdentity: "identity-v2",
+	}
+	secondIdentity := *identity
+	secondIdentity.secretKey = nil
+
+	require.NoError(t, identity.LoadSecret(""))
+	require.NoError(t, secondIdentity.LoadSecret(""))
+	assert.Equal(t, 1, mockDevice.GetHmacSecretCalls)
+	assert.Equal(t, identity.secretKey, secondIdentity.secretKey)
+
+	identity.ClearSecret()
+	assert.True(t, cache.Has("identity-v2"))
+	cache.Close()
+	for i, value := range secondIdentity.secretKey {
+		assert.Zero(t, value, "cached byte %d not cleared", i)
+	}
+}
+
+func TestSessionCacheDoesNotReuseVersion1Secret(t *testing.T) {
+	secret := make([]byte, 32)
+	_, err := rand.Read(secret)
+	require.NoError(t, err)
+
+	mockDevice := &MockFido2Device{HmacSecret: secret}
+	cache := NewSessionCache()
+	defer cache.Close()
+
+	identity := &Fido2HmacIdentity{
+		Version:         1,
+		CredId:          make([]byte, 50),
+		Device:          mockDevice,
+		UI:              newMockUI(nil, func(string) error { return nil }, nil),
+		sessionCache:    cache,
+		sessionIdentity: "identity-v1",
+	}
+	secondIdentity := *identity
+	secondIdentity.secretKey = nil
+
+	require.NoError(t, identity.LoadSecret(""))
+	identity.ClearSecret()
+	require.NoError(t, secondIdentity.LoadSecret(""))
+	assert.Equal(t, 2, mockDevice.GetHmacSecretCalls)
+}
+
 func TestLoadSecret_PinRequiredButMissing(t *testing.T) {
 	mockDevice := &MockFido2Device{}
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -53,6 +53,12 @@ type Fido2HmacIdentity struct {
 	Plugin *page.Plugin
 	UI     *page.ClientUI
 
+	// sessionCache and sessionIdentity are set only by the command-scoped
+	// session broker. The cache is deliberately limited to version-2
+	// identities, whose HMAC salt is stable across age files.
+	sessionCache    *SessionCache
+	sessionIdentity string
+
 	Nonce  []byte
 	Device Fido2Device
 }

--- a/pkg/plugin/session.go
+++ b/pkg/plugin/session.go
@@ -146,32 +146,38 @@ func (s *SessionServer) serveConnection(conn net.Conn) error {
 	}
 	p.SetIO(conn, conn, os.Stderr)
 	p.HandleIdentityEncoding(func(identity string) (age.Identity, error) {
-		i, err := ParseFido2HmacIdentity(identity)
-		if err != nil {
-			return nil, err
-		}
-
-		i.sessionCache = s.cache
-		i.sessionIdentity = identity
-		i.Plugin = p
-
-		// A cache hit does not require a live token device. This matters when a
-		// user removes the token after authorizing the batch.
-		if s.cache.Has(identity) {
-			return i, nil
-		}
-
-		i.Device, err = FindDevice(50*time.Second, p.DisplayMessage)
-		if err != nil {
-			return nil, err
-		}
-		return i, nil
+		return s.identityForSession(identity, p)
 	})
 
 	if exitCode := p.IdentityV1(); exitCode != 0 {
 		return fmt.Errorf("identity-v1 handler exited with status %d", exitCode)
 	}
 	return nil
+}
+
+func (s *SessionServer) identityForSession(identity string, p *page.Plugin) (*Fido2HmacIdentity, error) {
+	i, err := ParseFido2HmacIdentity(identity)
+	if err != nil {
+		return nil, err
+	}
+
+	i.sessionCache = s.cache
+	i.sessionIdentity = identity
+	i.Plugin = p
+
+	// Attach the cached secret immediately. Besides avoiding a second token
+	// lookup, this keeps every unwrap path independent of a live device after
+	// the first authorization.
+	if secret, ok := s.cache.Get(identity); ok {
+		i.secretKey = secret
+		return i, nil
+	}
+
+	i.Device, err = FindDevice(50*time.Second, p.DisplayMessage)
+	if err != nil {
+		return nil, err
+	}
+	return i, nil
 }
 
 func authenticateSession(conn net.Conn, expected []byte) error {

--- a/pkg/plugin/session.go
+++ b/pkg/plugin/session.go
@@ -1,0 +1,259 @@
+package plugin
+
+import (
+	"crypto/subtle"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"filippo.io/age"
+	page "filippo.io/age/plugin"
+)
+
+const (
+	SessionSocketEnv     = "AGE_PLUGIN_FIDO2_HMAC_SESSION_SOCKET"
+	SessionCapabilityEnv = "AGE_PLUGIN_FIDO2_HMAC_SESSION_CAPABILITY"
+	sessionHandshakeText = "age-plugin-fido2-hmac-session-v1\x00"
+)
+
+// SessionServer serves ordinary age identity-v1 plugin connections while
+// sharing a cache between them. The server itself never exposes the derived
+// identity to a client; each connection still receives only the file key that
+// the age protocol requires.
+type SessionServer struct {
+	listener   net.Listener
+	socketPath string
+	capability []byte
+	cache      *SessionCache
+	wg         sync.WaitGroup
+	closeOnce  sync.Once
+}
+
+// NewSessionServer creates a server on socketPath. The socket is restricted to
+// the current user and the capability is required in addition to filesystem
+// permissions so an accidentally reused path cannot attach to a session.
+func NewSessionServer(socketPath string, capability []byte, cache *SessionCache) (*SessionServer, error) {
+	if socketPath == "" {
+		return nil, errors.New("session socket path is empty")
+	}
+	if len(capability) == 0 {
+		return nil, errors.New("session capability is empty")
+	}
+	if cache == nil {
+		cache = NewSessionCache()
+	}
+
+	if err := os.MkdirAll(filepath.Dir(socketPath), 0o700); err != nil {
+		return nil, fmt.Errorf("create session directory: %w", err)
+	}
+	if info, err := os.Lstat(socketPath); err == nil {
+		if info.Mode()&os.ModeSocket == 0 {
+			return nil, fmt.Errorf("session socket path exists and is not a socket: %s", socketPath)
+		}
+		if err := os.Remove(socketPath); err != nil {
+			return nil, fmt.Errorf("remove stale session socket: %w", err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("inspect session socket path: %w", err)
+	}
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("listen on session socket: %w", err)
+	}
+	if err := os.Chmod(socketPath, 0o600); err != nil {
+		_ = listener.Close()
+		_ = os.Remove(socketPath)
+		return nil, fmt.Errorf("protect session socket: %w", err)
+	}
+
+	capabilityCopy := append([]byte(nil), capability...)
+	return &SessionServer{
+		listener:   listener,
+		socketPath: socketPath,
+		capability: capabilityCopy,
+		cache:      cache,
+	}, nil
+}
+
+// SocketPath returns the private socket used by this session.
+func (s *SessionServer) SocketPath() string {
+	if s == nil {
+		return ""
+	}
+	return s.socketPath
+}
+
+// Serve accepts proxy connections until Close is called.
+func (s *SessionServer) Serve() error {
+	for {
+		conn, err := s.listener.Accept()
+		if err != nil {
+			if errors.Is(err, net.ErrClosed) {
+				return nil
+			}
+			return err
+		}
+
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			_ = s.serveConnection(conn)
+		}()
+	}
+}
+
+// Close stops accepting connections, waits for active protocol handlers, and
+// clears all cached derived secrets.
+func (s *SessionServer) Close() error {
+	if s == nil {
+		return nil
+	}
+
+	var err error
+	s.closeOnce.Do(func() {
+		err = s.listener.Close()
+		s.wg.Wait()
+		s.cache.Close()
+		// Keep the path separately: after Close, a net.UnixListener's Addr is
+		// implementation-dependent and may no longer be safe to inspect.
+		_ = os.Remove(s.socketPath)
+		for i := range s.capability {
+			s.capability[i] = 0
+		}
+	})
+	if errors.Is(err, net.ErrClosed) {
+		return nil
+	}
+	return err
+}
+
+func (s *SessionServer) serveConnection(conn net.Conn) error {
+	defer conn.Close()
+
+	if err := authenticateSession(conn, s.capability); err != nil {
+		return err
+	}
+
+	p, err := page.New(PLUGIN_NAME)
+	if err != nil {
+		return err
+	}
+	p.SetIO(conn, conn, os.Stderr)
+	p.HandleIdentityEncoding(func(identity string) (age.Identity, error) {
+		i, err := ParseFido2HmacIdentity(identity)
+		if err != nil {
+			return nil, err
+		}
+
+		i.sessionCache = s.cache
+		i.sessionIdentity = identity
+		i.Plugin = p
+
+		// A cache hit does not require a live token device. This matters when a
+		// user removes the token after authorizing the batch.
+		if s.cache.Has(identity) {
+			return i, nil
+		}
+
+		i.Device, err = FindDevice(50*time.Second, p.DisplayMessage)
+		if err != nil {
+			return nil, err
+		}
+		return i, nil
+	})
+
+	if exitCode := p.IdentityV1(); exitCode != 0 {
+		return fmt.Errorf("identity-v1 handler exited with status %d", exitCode)
+	}
+	return nil
+}
+
+func authenticateSession(conn net.Conn, expected []byte) error {
+	magic := make([]byte, len(sessionHandshakeText))
+	if _, err := io.ReadFull(conn, magic); err != nil {
+		return fmt.Errorf("read session handshake: %w", err)
+	}
+	if string(magic) != sessionHandshakeText {
+		return errors.New("invalid session handshake")
+	}
+
+	capability := make([]byte, len(expected))
+	if _, err := io.ReadFull(conn, capability); err != nil {
+		return fmt.Errorf("read session capability: %w", err)
+	}
+	if subtle.ConstantTimeCompare(capability, expected) != 1 {
+		return errors.New("invalid session capability")
+	}
+	for i := range capability {
+		capability[i] = 0
+	}
+	return nil
+}
+
+// ProxySession turns one ordinary age plugin process into a connection to a
+// command-scoped session server. It returns only after both sides close.
+func ProxySession(socketPath string, capability []byte) error {
+	if socketPath == "" || len(capability) == 0 {
+		return errors.New("session environment is incomplete")
+	}
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		return fmt.Errorf("connect to session broker: %w", err)
+	}
+	defer conn.Close()
+
+	if _, err := io.WriteString(conn, sessionHandshakeText); err != nil {
+		return fmt.Errorf("write session handshake: %w", err)
+	}
+	if _, err := conn.Write(capability); err != nil {
+		return fmt.Errorf("write session capability: %w", err)
+	}
+
+	copyDone := make(chan error, 2)
+	go func() {
+		_, copyErr := io.Copy(conn, os.Stdin)
+		if unixConn, ok := conn.(*net.UnixConn); ok {
+			_ = unixConn.CloseWrite()
+		}
+		copyDone <- copyErr
+	}()
+	go func() {
+		_, copyErr := io.Copy(os.Stdout, conn)
+		copyDone <- copyErr
+	}()
+
+	first := <-copyDone
+	second := <-copyDone
+	if first != nil && !errors.Is(first, net.ErrClosed) {
+		return first
+	}
+	if second != nil && !errors.Is(second, net.ErrClosed) {
+		return second
+	}
+	return nil
+}
+
+// SessionCapabilityString is used by the command wrapper when constructing
+// the child environment. Keeping the encoding here avoids accidental shell
+// quoting or binary environment values.
+func SessionCapabilityString(capability []byte) string {
+	return hex.EncodeToString(capability)
+}
+
+// ParseSessionCapability decodes the environment representation.
+func ParseSessionCapability(value string) ([]byte, error) {
+	if value == "" {
+		return nil, errors.New("session capability is empty")
+	}
+	capability, err := hex.DecodeString(value)
+	if err != nil {
+		return nil, fmt.Errorf("decode session capability: %w", err)
+	}
+	return capability, nil
+}

--- a/pkg/plugin/session_cache.go
+++ b/pkg/plugin/session_cache.go
@@ -1,0 +1,116 @@
+package plugin
+
+import (
+	"errors"
+	"sync"
+)
+
+// SessionCache keeps derived version-2 HMAC secrets alive for the lifetime of
+// one explicit session. It never persists a PIN or an identity encoding.
+//
+// The cached byte slices are owned by the cache. Callers must treat the
+// returned bytes as immutable and must not clear them directly.
+type SessionCache struct {
+	mu      sync.Mutex
+	entries map[string][]byte
+	loading map[string]*sessionLoad
+	closed  bool
+}
+
+type sessionLoad struct {
+	done   chan struct{}
+	secret []byte
+	err    error
+}
+
+// NewSessionCache creates an empty cache for one command-scoped session.
+func NewSessionCache() *SessionCache {
+	return &SessionCache{
+		entries: make(map[string][]byte),
+		loading: make(map[string]*sessionLoad),
+	}
+}
+
+// Has reports whether key has already been loaded in this session.
+func (c *SessionCache) Has(key string) bool {
+	if c == nil || key == "" {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	_, ok := c.entries[key]
+	return ok && !c.closed
+}
+
+// Load returns the cached value or calls load exactly once for concurrent
+// callers requesting the same key. The load function must return a secret that
+// has already been mlocked by the caller.
+func (c *SessionCache) Load(key string, load func() ([]byte, error)) ([]byte, error) {
+	if c == nil || key == "" {
+		return load()
+	}
+
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return nil, errors.New("session cache is closed")
+	}
+	if secret, ok := c.entries[key]; ok {
+		c.mu.Unlock()
+		return secret, nil
+	}
+	if pending, ok := c.loading[key]; ok {
+		c.mu.Unlock()
+		<-pending.done
+		return pending.secret, pending.err
+	}
+
+	pending := &sessionLoad{done: make(chan struct{})}
+	c.loading[key] = pending
+	c.mu.Unlock()
+
+	secret, err := load()
+
+	c.mu.Lock()
+	delete(c.loading, key)
+	pending.secret = secret
+	pending.err = err
+	if err == nil && c.closed {
+		pending.err = errors.New("session cache closed while loading secret")
+	} else if err == nil {
+		c.entries[key] = secret
+	}
+	close(pending.done)
+	c.mu.Unlock()
+
+	if pending.err != nil && err == nil {
+		for i := range secret {
+			secret[i] = 0
+		}
+		return nil, pending.err
+	}
+	return secret, pending.err
+}
+
+// Close clears every cached secret. It is idempotent and should be called by
+// the session wrapper on every exit path.
+func (c *SessionCache) Close() {
+	if c == nil {
+		return
+	}
+
+	c.mu.Lock()
+	if c.closed {
+		c.mu.Unlock()
+		return
+	}
+	c.closed = true
+	for key, secret := range c.entries {
+		for i := range secret {
+			secret[i] = 0
+		}
+		delete(c.entries, key)
+	}
+	c.mu.Unlock()
+}

--- a/pkg/plugin/session_cache.go
+++ b/pkg/plugin/session_cache.go
@@ -33,14 +33,22 @@ func NewSessionCache() *SessionCache {
 
 // Has reports whether key has already been loaded in this session.
 func (c *SessionCache) Has(key string) bool {
+	_, ok := c.Get(key)
+	return ok
+}
+
+// Get returns a cached secret without transferring ownership to the caller.
+// The returned slice remains owned by the cache and is cleared when the
+// command-scoped session closes.
+func (c *SessionCache) Get(key string) ([]byte, bool) {
 	if c == nil || key == "" {
-		return false
+		return nil, false
 	}
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	_, ok := c.entries[key]
-	return ok && !c.closed
+	secret, ok := c.entries[key]
+	return secret, ok && !c.closed
 }
 
 // Load returns the cached value or calls load exactly once for concurrent

--- a/pkg/plugin/session_cache_test.go
+++ b/pkg/plugin/session_cache_test.go
@@ -1,9 +1,28 @@
 package plugin
 
 import (
+	"bytes"
 	"sync"
 	"testing"
 )
+
+func TestSessionCacheGetReturnsLoadedSecret(t *testing.T) {
+	cache := NewSessionCache()
+	defer cache.Close()
+
+	want := []byte("command-scoped secret")
+	if _, err := cache.Load("identity", func() ([]byte, error) { return want, nil }); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	got, ok := cache.Get("identity")
+	if !ok {
+		t.Fatal("Get missed a loaded identity")
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("Get returned %q, want %q", got, want)
+	}
+}
 
 func TestSessionCacheCloseWakesConcurrentLoaders(t *testing.T) {
 	cache := NewSessionCache()

--- a/pkg/plugin/session_cache_test.go
+++ b/pkg/plugin/session_cache_test.go
@@ -1,0 +1,38 @@
+package plugin
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestSessionCacheCloseWakesConcurrentLoaders(t *testing.T) {
+	cache := NewSessionCache()
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+
+	load := func() ([]byte, error) {
+		once.Do(func() { close(started) })
+		<-release
+		return []byte("derived-secret"), nil
+	}
+
+	results := make(chan error, 2)
+	go func() {
+		_, err := cache.Load("identity", load)
+		results <- err
+	}()
+	<-started
+	go func() {
+		_, err := cache.Load("identity", load)
+		results <- err
+	}()
+
+	cache.Close()
+	close(release)
+	for range 2 {
+		if err := <-results; err == nil {
+			t.Fatal("loader succeeded after session cache was closed")
+		}
+	}
+}

--- a/pkg/plugin/session_test.go
+++ b/pkg/plugin/session_test.go
@@ -1,12 +1,40 @@
 package plugin
 
 import (
+	"bytes"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
+
+func TestIdentityForSessionAttachesCachedSecret(t *testing.T) {
+	cache := NewSessionCache()
+	defer cache.Close()
+
+	encoded := (&Fido2HmacIdentity{
+		Version: 2,
+		Salt:    make([]byte, 32),
+		CredId:  make([]byte, 50),
+	}).String()
+	want := bytes.Repeat([]byte{0x42}, 32)
+	if _, err := cache.Load(encoded, func() ([]byte, error) { return want, nil }); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	server := &SessionServer{cache: cache}
+	identity, err := server.identityForSession(encoded, nil)
+	if err != nil {
+		t.Fatalf("identityForSession: %v", err)
+	}
+	if !bytes.Equal(identity.secretKey, want) {
+		t.Fatal("identity did not receive the cached secret")
+	}
+	if err := identity.LoadSecret(""); err != nil {
+		t.Fatalf("cached identity tried to use a device: %v", err)
+	}
+}
 
 func TestNewSessionServerRejectsNonSocketPath(t *testing.T) {
 	dir := t.TempDir()

--- a/pkg/plugin/session_test.go
+++ b/pkg/plugin/session_test.go
@@ -1,0 +1,52 @@
+package plugin
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestNewSessionServerRejectsNonSocketPath(t *testing.T) {
+	dir := t.TempDir()
+	socketPath := filepath.Join(dir, "session.sock")
+	if err := os.WriteFile(socketPath, []byte("keep me"), 0o600); err != nil {
+		t.Fatalf("create sentinel: %v", err)
+	}
+
+	_, err := NewSessionServer(socketPath, []byte("capability"), NewSessionCache())
+	if err == nil {
+		t.Fatal("NewSessionServer accepted a regular file as its socket path")
+	}
+	if !strings.Contains(err.Error(), "not a socket") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	contents, readErr := os.ReadFile(socketPath)
+	if readErr != nil {
+		t.Fatalf("sentinel was removed: %v", readErr)
+	}
+	if string(contents) != "keep me" {
+		t.Fatalf("sentinel changed: %q", contents)
+	}
+}
+
+func TestSessionServerCloseRemovesSocket(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "session.sock")
+	server, err := NewSessionServer(socketPath, []byte("capability"), NewSessionCache())
+	if err != nil {
+		t.Fatalf("NewSessionServer: %v", err)
+	}
+
+	serveDone := make(chan error, 1)
+	go func() { serveDone <- server.Serve() }()
+	if err := server.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if err := <-serveDone; err != nil {
+		t.Fatalf("Serve after Close: %v", err)
+	}
+	if _, err := os.Stat(socketPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("socket path still exists: %v", err)
+	}
+}


### PR DESCRIPTION
This adds `age-plugin-fido2-hmac-session`, a command wrapper and Unix-socket broker for ordinary identity-v1 plugin subprocesses. Version-2 derived HMAC secrets are reused from mlocked memory for the command lifetime and cleared on exit; version-1 identities retain per-file salt semantics.

On a cache hit, the broker attaches the cached key to the new identity before handling stanzas. This avoids a nil-device failure in later decryptions and means the token can be removed after the first authorization.

Validation: the full Go test suite passes in canix's Nix package build. Regression coverage verifies that a second session identity can load its cached key without a device.
